### PR TITLE
Fix translation labels

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -734,6 +734,9 @@ class FrontendHooks
 				if ($id && !empty($GLOBALS['TL_LANG'][$ptable]['edit'][1])) {
 					return sprintf(is_array($GLOBALS['TL_LANG'][$ptable]['edit']) ? $GLOBALS['TL_LANG'][$ptable]['edit'][1] : $GLOBALS['TL_LANG'][$ptable]['edit'], $id);
 				}
+				if (!empty($GLOBALS['TL_LANG'][$ptable]['editmeta'])) {
+					return $GLOBALS['TL_LANG'][$ptable]['editmeta'];
+				}
 				if (!empty($GLOBALS['TL_LANG'][$ptable]['edit'][0])) {
 					return $GLOBALS['TL_LANG'][$ptable]['edit'][0];
 				}

--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -747,13 +747,13 @@ class FrontendHooks
 		}
 		\System::loadLanguageFile($config['table']);
 		if (!empty($GLOBALS['TL_LANG'][$config['table']]['editheader'][0])) {
-            return is_array($GLOBALS['TL_LANG'][$config['table']]['editheader']) ? $GLOBALS['TL_LANG'][$config['table']]['editheader'][0] : $GLOBALS['TL_LANG'][$config['table']]['editheader'];
+			return is_array($GLOBALS['TL_LANG'][$config['table']]['editheader']) ? $GLOBALS['TL_LANG'][$config['table']]['editheader'][0] : $GLOBALS['TL_LANG'][$config['table']]['editheader'];
 		}
 		if ($id && !empty($GLOBALS['TL_LANG'][$config['table']]['edit'][1])) {
 			return sprintf(is_array($GLOBALS['TL_LANG'][$config['table']]['edit']) ? $GLOBALS['TL_LANG'][$config['table']]['edit'][1] : $GLOBALS['TL_LANG'][$config['table']]['edit'], $id);
 		}
 		if (!empty($GLOBALS['TL_LANG'][$config['table']]['edit'][0])) {
-            return is_array($GLOBALS['TL_LANG'][$config['table']]['edit']) ? $GLOBALS['TL_LANG'][$config['table']]['edit'][0] : $GLOBALS['TL_LANG'][$config['table']]['edit'];
+			return is_array($GLOBALS['TL_LANG'][$config['table']]['edit']) ? $GLOBALS['TL_LANG'][$config['table']]['edit'][0] : $GLOBALS['TL_LANG'][$config['table']]['edit'];
 		}
 		if ($id) {
 			return sprintf($GLOBALS['TL_LANG']['MSC']['editRecord'], $id);

--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -130,10 +130,10 @@ class FrontendHooks
 				$content = str_replace($matches2[0], $matches2[1] . $matches2[3], $content);
 
 				if (in_array('beModules', $permissions)) {
-					\System::loadLanguageFile('tl_calendar');
+					\System::loadLanguageFile('tl_calendar_events');
 					$data['links']['be-module'] = array(
 						'url' => static::getBackendURL('calendar', 'tl_content', $matches2[2], false),
-						'label' => sprintf(is_array($GLOBALS['TL_LANG']['tl_calendar']['edit']) ? $GLOBALS['TL_LANG']['tl_calendar']['edit'][1] : $GLOBALS['TL_LANG']['tl_calendar']['edit'], $matches2[2]),
+						'label' => sprintf(is_array($GLOBALS['TL_LANG']['tl_calendar_events']['edit']) ? $GLOBALS['TL_LANG']['tl_calendar_events']['edit'][1] : $GLOBALS['TL_LANG']['tl_calendar_events']['edit'], $matches2[2]),
 						'icon' => \Image::getPath('settings.svg'),
 					);
 				}

--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -738,22 +738,22 @@ class FrontendHooks
 					return $GLOBALS['TL_LANG'][$ptable]['editmeta'];
 				}
 				if (!empty($GLOBALS['TL_LANG'][$ptable]['edit'][0])) {
-					return $GLOBALS['TL_LANG'][$ptable]['edit'][0];
+					return is_array($GLOBALS['TL_LANG'][$ptable]['edit']) ? $GLOBALS['TL_LANG'][$ptable]['edit'][0] : $GLOBALS['TL_LANG'][$ptable]['edit'];
 				}
 				if (!empty($GLOBALS['TL_LANG'][$ptable]['editheader'][0])) {
-					return $GLOBALS['TL_LANG'][$ptable]['editheader'][0];
+					return is_array($GLOBALS['TL_LANG'][$ptable]['editheader']) ? $GLOBALS['TL_LANG'][$ptable]['editheader'][0] : $GLOBALS['TL_LANG'][$ptable]['editheader'];
 				}
 			}
 		}
 		\System::loadLanguageFile($config['table']);
 		if (!empty($GLOBALS['TL_LANG'][$config['table']]['editheader'][0])) {
-			return $GLOBALS['TL_LANG'][$config['table']]['editheader'][0];
+            return is_array($GLOBALS['TL_LANG'][$config['table']]['editheader']) ? $GLOBALS['TL_LANG'][$config['table']]['editheader'][0] : $GLOBALS['TL_LANG'][$config['table']]['editheader'];
 		}
 		if ($id && !empty($GLOBALS['TL_LANG'][$config['table']]['edit'][1])) {
 			return sprintf(is_array($GLOBALS['TL_LANG'][$config['table']]['edit']) ? $GLOBALS['TL_LANG'][$config['table']]['edit'][1] : $GLOBALS['TL_LANG'][$config['table']]['edit'], $id);
 		}
 		if (!empty($GLOBALS['TL_LANG'][$config['table']]['edit'][0])) {
-			return $GLOBALS['TL_LANG'][$config['table']]['edit'][0];
+            return is_array($GLOBALS['TL_LANG'][$config['table']]['edit']) ? $GLOBALS['TL_LANG'][$config['table']]['edit'][0] : $GLOBALS['TL_LANG'][$config['table']]['edit'];
 		}
 		if ($id) {
 			return sprintf($GLOBALS['TL_LANG']['MSC']['editRecord'], $id);


### PR DESCRIPTION
If you have a e.g. news or event list with multiple linked archives, currently only the first letter of `$GLOBALS['TL_LANG'][$ptable]['edit'][0]` is used as label.

But I think the translation key `$GLOBALS['TL_LANG'][$ptable]['editmeta']` would be the better key, wouldn't it?

EDIT: I added some more fixes for wrong translations

But the longer I look at the code with the labels, the more I think that the whole logic needs to be cleaned up - especially for the case with / without ID. And why is there different logic order for the parent label?
