### PR TITLE
Use the PaletteManipulator

### DIFF
--- a/src/Resources/contao/dca/tl_user.php
+++ b/src/Resources/contao/dca/tl_user.php
@@ -13,11 +13,11 @@
  */
 
 \Contao\CoreBundle\DataContainer\PaletteManipulator::create()
-    ->addLegend('rocksolid_frontend_helper_legend', 'forms_legend')
-    ->addField('rocksolidFrontendHelperOperations', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-    ->addField('rocksolidFrontendHelperContentElements', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-    ->applyToPalette('extend', 'tl_user')
-    ->applyToPalette('custom', 'tl_user')
+	->addLegend('rocksolid_frontend_helper_legend', 'forms_legend')
+	->addField('rocksolidFrontendHelperOperations', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+	->addField('rocksolidFrontendHelperContentElements', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+	->applyToPalette('extend', 'tl_user')
+	->applyToPalette('custom', 'tl_user')
 ;
 
 $GLOBALS['TL_DCA']['tl_user']['palettes']['admin'] = preg_replace('(([,;}]useCE)([,;{]))i', '$1,rocksolidFrontendHelper,rocksolidFrontendHelperLightbox$2', $GLOBALS['TL_DCA']['tl_user']['palettes']['admin']);

--- a/src/Resources/contao/dca/tl_user.php
+++ b/src/Resources/contao/dca/tl_user.php
@@ -12,8 +12,13 @@
  * @author Martin Auswöger <martin@madeyourday.net>
  */
 
-$GLOBALS['TL_DCA']['tl_user']['palettes']['extend'] = str_replace('formp;', 'formp;{rocksolid_frontend_helper_legend},rocksolidFrontendHelperOperations,rocksolidFrontendHelperContentElements;', $GLOBALS['TL_DCA']['tl_user']['palettes']['extend']);
-$GLOBALS['TL_DCA']['tl_user']['palettes']['custom'] = str_replace('formp;', 'formp;{rocksolid_frontend_helper_legend},rocksolidFrontendHelperOperations,rocksolidFrontendHelperContentElements;', $GLOBALS['TL_DCA']['tl_user']['palettes']['custom']);
+\Contao\CoreBundle\DataContainer\PaletteManipulator::create()
+    ->addLegend('rocksolid_frontend_helper_legend', 'forms_legend')
+    ->addField('rocksolidFrontendHelperOperations', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+    ->addField('rocksolidFrontendHelperContentElements', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('extend', 'tl_user')
+    ->applyToPalette('custom', 'tl_user')
+;
 
 $GLOBALS['TL_DCA']['tl_user']['palettes']['admin'] = preg_replace('(([,;}]useCE)([,;{]))i', '$1,rocksolidFrontendHelper,rocksolidFrontendHelperLightbox$2', $GLOBALS['TL_DCA']['tl_user']['palettes']['admin']);
 $GLOBALS['TL_DCA']['tl_user']['palettes']['default'] = preg_replace('(([,;}]useCE)([,;{]))i', '$1,rocksolidFrontendHelper,rocksolidFrontendHelperLightbox$2', $GLOBALS['TL_DCA']['tl_user']['palettes']['default']);

--- a/src/Resources/contao/dca/tl_user_group.php
+++ b/src/Resources/contao/dca/tl_user_group.php
@@ -13,10 +13,10 @@
  */
 
 \Contao\CoreBundle\DataContainer\PaletteManipulator::create()
-    ->addLegend('rocksolid_frontend_helper_legend', 'forms_legend')
-    ->addField('rocksolidFrontendHelperOperations', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-    ->addField('rocksolidFrontendHelperContentElements', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
-    ->applyToPalette('default', 'tl_user_group')
+	->addLegend('rocksolid_frontend_helper_legend', 'forms_legend')
+	->addField('rocksolidFrontendHelperOperations', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+	->addField('rocksolidFrontendHelperContentElements', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+	->applyToPalette('default', 'tl_user_group')
 ;
 
 $GLOBALS['TL_DCA']['tl_user_group']['fields']['rocksolidFrontendHelperOperations'] = array(

--- a/src/Resources/contao/dca/tl_user_group.php
+++ b/src/Resources/contao/dca/tl_user_group.php
@@ -12,7 +12,12 @@
  * @author Martin Auswöger <martin@madeyourday.net>
  */
 
-$GLOBALS['TL_DCA']['tl_user_group']['palettes']['default'] = str_replace('formp;', 'formp;{rocksolid_frontend_helper_legend},rocksolidFrontendHelperOperations,rocksolidFrontendHelperContentElements;', $GLOBALS['TL_DCA']['tl_user_group']['palettes']['default']);
+\Contao\CoreBundle\DataContainer\PaletteManipulator::create()
+    ->addLegend('rocksolid_frontend_helper_legend', 'forms_legend')
+    ->addField('rocksolidFrontendHelperOperations', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+    ->addField('rocksolidFrontendHelperContentElements', 'rocksolid_frontend_helper_legend', \Contao\CoreBundle\DataContainer\PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('default', 'tl_user_group')
+;
 
 $GLOBALS['TL_DCA']['tl_user_group']['fields']['rocksolidFrontendHelperOperations'] = array(
 	'label' => &$GLOBALS['TL_LANG']['tl_user']['rocksolidFrontendHelperOperations'],


### PR DESCRIPTION
Otherwise it might be that the settings are completely hidden (e.g. in our case, we had an extension that added a field after `formp` so it was not `formp;` anymore :) 