### PR TITLE
Fix a potential warning if the global $objPage is not available

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -840,7 +840,7 @@ class FrontendHooks
 			$data['templateURL'] = static::getBackendURL('tpl_editor', null, null, null, array(
 				'key' => 'new_tpl',
 				'original' => $data['templatePath'],
-				'target' => (isset($GLOBALS['objPage']) && $GLOBALS['objPage']->templateGroup) ? $GLOBALS['objPage']->templateGroup : 'templates',
+				'target' => ($GLOBALS['objPage']->templateGroup ?? null) ?: 'templates',
 			));
 
 			System::loadLanguageFile('tl_templates');

--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -840,7 +840,7 @@ class FrontendHooks
 			$data['templateURL'] = static::getBackendURL('tpl_editor', null, null, null, array(
 				'key' => 'new_tpl',
 				'original' => $data['templatePath'],
-				'target' => $GLOBALS['objPage']->templateGroup ?: 'templates',
+				'target' => (isset($GLOBALS['objPage']) && $GLOBALS['objPage']->templateGroup) ? $GLOBALS['objPage']->templateGroup : 'templates',
 			));
 
 			System::loadLanguageFile('tl_templates');


### PR DESCRIPTION
We just had this in Contao 5.2 in an AJAX request, where apparently the global `$objPage` is not available.

```
ErrorException: Warning: Attempt to read property "templateGroup" on null

#21 /vendor/madeyourday/contao-rocksolid-frontend-helper/src/FrontendHooks.php(843): MadeYourDay\RockSolidFrontendHelper\FrontendHooks::addTemplateURL
#20 /vendor/madeyourday/contao-rocksolid-frontend-helper/src/FrontendHooks.php(96): MadeYourDay\RockSolidFrontendHelper\FrontendHooks::parseFrontendTemplateHook
#19 /vendor/contao/core-bundle/contao/classes/FrontendTemplate.php(50): Contao\FrontendTemplate::parse
#18 /vendor/contao/core-bundle/contao/library/Contao/TemplateInheritance.php(337): Contao\Template::insert
…
```