### PR TITLE
Fix icons for Contao 5

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -160,7 +160,7 @@ class FrontendHooks
 					$data['links']['be-module'] = array(
 						'url' => static::getBackendURL('news', 'tl_content', $matches2[2], false),
 						'label' => sprintf(is_array($GLOBALS['TL_LANG']['tl_news']['edit']) ? $GLOBALS['TL_LANG']['tl_news']['edit'][1] : $GLOBALS['TL_LANG']['tl_news']['edit'], $matches2[2]),
-						'icon' => Image::getPath('news.svg'),
+						'icon' => Image::getPath('bundles/contaonews/news.svg'),
 					);
 				}
 
@@ -178,7 +178,7 @@ class FrontendHooks
 					$data['links']['be-module'] = array(
 						'url' => static::getBackendURL('calendar', 'tl_content', $matches2[2], false),
 						'label' => sprintf(is_array($GLOBALS['TL_LANG']['tl_calendar_events']['edit']) ? $GLOBALS['TL_LANG']['tl_calendar_events']['edit'][1] : $GLOBALS['TL_LANG']['tl_calendar_events']['edit'], $matches2[2]),
-						'icon' => Image::getPath('settings.svg'),
+						'icon' => Image::getPath('bundles/contaocalendar/calendar.svg'),
 					);
 				}
 

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -20,7 +20,7 @@ rocksolid_frontend_helper:
             table: tl_news
             column: news_archives
             column_type: serialized
-            icon: news.svg
+            icon: bundles/contaonews/news.svg
             fe_modules:
                 - newslist
                 - newsreader
@@ -31,7 +31,7 @@ rocksolid_frontend_helper:
             table: tl_calendar_events
             column: cal_calendar
             column_type: serialized
-            icon: settings.svg
+            icon: bundles/contaocalendar/calendar.svg
             fe_modules:
                 - calendar
                 - eventreader
@@ -42,7 +42,7 @@ rocksolid_frontend_helper:
             table: tl_newsletter
             column: nl_channels
             column_type: serialized
-            icon: bundles/contaonewsletter/icon.svg
+            icon: bundles/contaonewsletter/send.svg
             fe_modules:
                 - nl_list
                 - nl_reader
@@ -63,7 +63,7 @@ rocksolid_frontend_helper:
             table: tl_faq
             column: faq_categories
             column_type: serialized
-            icon: settings.svg
+            icon: bundles/contaofaq/faq.svg
             fe_modules:
                 - faqlist
                 - faqreader


### PR DESCRIPTION
Fix the icons for contao 5 because the `news.svg` is missing.
I also edited the icons for events + faqs because they are better then the common `settings.svg`
The icon `bundles/contaonewsletter/icon.svg` does not exist anymore.

The changes should be also compatible with contao 4.13!