### PR TITLE
fix: All frontend helper texts are in the backend language.

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidFrontendHelper;
 
+use Contao\BackendUser;
 use Contao\Controller;
 use Contao\CoreBundle\Util\PackageUtil;
 use Contao\Database;
@@ -71,6 +72,8 @@ class FrontendHooks
 		if (!($permissions = static::checkLogin()) || !$template) {
 			return $content;
 		}
+
+        $GLOBALS['TL_LANGUAGE'] = BackendUser::getInstance()->language;
 
 		$data = array();
 


### PR DESCRIPTION
Most of these texts were in the frontend language, with this fix they are in the language of the backend.
![image](https://github.com/user-attachments/assets/6e5db850-3770-479d-824d-daa2cdcac224)
