### PR TITLE
Do not throw exception on twig widget templates

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -451,7 +451,14 @@ class FrontendHooks
 			&& $widget->template !== 'form_rs_columns_plain'
 		) {
 			$data['template'] = $widget->template;
-			$data['templatePath'] = substr($widget->getTemplate($widget->template), strlen(System::getContainer()->getParameter('kernel.project_dir')) + 1);
+			try {
+				$data['templatePath'] = substr(
+					$widget->getTemplate($widget->template),
+					strlen(System::getContainer()->getParameter('kernel.project_dir')) + 1
+				);
+			} catch (\Exception) {
+				return $content;
+			}
 			if (in_array('tpl_editor', $permissions)) {
 				$data = static::addTemplateURL($data);
 			}


### PR DESCRIPTION
This PR wraps the template load method in FrontendHooks::parseWidgetHook() in a try/catch tofix exceptions when a widget template is created as twig template. This is just a quick fix, it would be better to also support twig templates as in the contao core.

I got this error when using FrontendHelper together with https://github.com/plenta/contao-extended-checkbox/tree/2.0, which has twig templates as widget templates.