### PR TITLE
Do not show template editor links if the module does not exist

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -916,9 +916,9 @@ class FrontendHooks
 	 */
 	protected static function insertData($content, $data)
 	{
-        if (empty($data)) {
-            return $content;
-        }
+		if (!$data) {
+			return $content;
+		}
 
 		if (
 			preg_match('(^.*?(?:<div class="rs-column(?:\\s[^"]*)?">)?.*?(?:<div class="rs-column-inner(?:\\s[^"]*)?">)?.*?<([a-z0-9]+)(?:\\s(?>"[^"]*"|\'[^\']*\'|[^>"\'])+|))is', $content, $matches)

--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -73,7 +73,7 @@ class FrontendHooks
 
 		$data = array();
 
-		if (in_array('infos', $permissions)) {
+		if (isset($GLOBALS['BE_MOD']['design']['tpl_editor']) && in_array('infos', $permissions)) {
 			try {
 				if (
 					($twig = System::getContainer()->get('twig', ContainerInterface::NULL_ON_INVALID_REFERENCE))
@@ -916,6 +916,10 @@ class FrontendHooks
 	 */
 	protected static function insertData($content, $data)
 	{
+        if (empty($data)) {
+            return $content;
+        }
+
 		if (
 			preg_match('(^.*?(?:<div class="rs-column(?:\\s[^"]*)?">)?.*?(?:<div class="rs-column-inner(?:\\s[^"]*)?">)?.*?<([a-z0-9]+)(?:\\s(?>"[^"]*"|\'[^\']*\'|[^>"\'])+|))is', $content, $matches)
 			&& $matches[1] !== 'esi'


### PR DESCRIPTION
When we deploy our systems, we always disable the template editor. Those links lead to nowhere and are useless then.