### PR TITLE
Remove a non-capturing catch to fix PHP 7.4 compatibility

### DIFF
--- a/src/FrontendHooks.php
+++ b/src/FrontendHooks.php
@@ -976,7 +976,7 @@ class FrontendHooks
 			}
 
 			return substr(Controller::getTemplate($template), strlen(System::getContainer()->getParameter('kernel.project_dir')) + 1);
-		} catch (\Throwable) {
+		} catch (\Throwable $e) {
 			// Ignore
 		}
 


### PR DESCRIPTION
PHP 7.4 does not support non-capturing catches, but the requirement of the extension allows 7.4.
We (unfortunately 😅 ) currently still have an installation with PHP 7.4, in which this problem currently breaks the whole installation.